### PR TITLE
Fix logic for preserving copp tables

### DIFF
--- a/cfgmgr/coppmgr.cpp
+++ b/cfgmgr/coppmgr.cpp
@@ -271,6 +271,14 @@ bool CoppMgr::isDupEntry(const std::string &key, std::vector<FieldValueTuple> &f
     }
     else
     {
+        // If size don't match this suggests that there is a difference in the fields that should be set for this key
+        if (preserved_fvs.size() != fvs.size())
+        {
+            // overwrite -> delete preserved entry from copp table and set a new entry instead
+            m_coppTable.del(key);
+            return false;
+        }
+
         unordered_map<string, string> preserved_copp_entry;
         for (auto prev_fv : preserved_fvs)
         {


### PR DESCRIPTION
**What I did**
Comparing the size of preserved entry with new entry can find a case when there's a difference between fields held by preserved copp entry and those in the copp entry.
In case the size of both entries is the same the difference will be found when iterating the fields.

**Why I did it**
The code didn't address the case where preserved copp entry holds different fields than the new copp entry.

**How I verified it**

**Details if related**
