### PR TITLE
workaround to set default routes for fast-reboot skipping timer

### DIFF
--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -21,8 +21,8 @@ using namespace swss;
 #define VRF_PREFIX              "Vrf"
 #define MGMT_VRF_PREFIX         "mgmt"
 
-#define IPV4_DEFAULT_ROUTE      "0.0.0.0/0"
-#define IPV6_DEFAULT_ROUTE      "::/0"
+#define IPV4_DEFAULT_GATEWAY      "0.0.0.0"
+#define IPV6_DEFAULT_GATEWAY      "::"
 
 #define NHG_DELIMITER ','
 
@@ -785,7 +785,7 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
         fvVector.push_back(wt);
     }
 
-    if (!warmRestartInProgress  || (fastRestartInProgress && isDefaultRoute(destipprefix)))
+    if (!warmRestartInProgress  || (fastRestartInProgress && isConnectedRoute(gw_list.c_str())))
     {
         m_routeTable.set(destipprefix, fvVector);
         SWSS_LOG_DEBUG("RouteTable set msg: %s %s %s %s", destipprefix,
@@ -809,12 +809,12 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
 }
 
 /* 
- * Check if given string route is IPV4/IPV6 default route
- * @arg route      route
+ * Check if given nexthop is default gateway.
+ * @arg nexthop      nexthop address
  */
-bool RouteSync::isDefaultRoute(char *route)
+bool RouteSync::isConnectedRoute(char *nexthop)
 {
-    return (!strcmp (route, IPV4_DEFAULT_ROUTE)) || (!strcmp (route, IPV6_DEFAULT_ROUTE));
+    return (!strcmp (route, IPV4_DEFAULT_GATEWAY)) || (!strcmp (route, IPV6_DEFAULT_GATEWAY));
 }
 
 /* 

--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -453,6 +453,7 @@ void RouteSync::onEvpnRouteMsg(struct nlmsghdr *h, int len)
         if (!warmRestartInProgress)
         {
             m_routeTable.del(destipprefix);
+            SWSS_LOG_NOTICE("afeigin2");
             return;
         }
         else
@@ -465,6 +466,7 @@ void RouteSync::onEvpnRouteMsg(struct nlmsghdr *h, int len)
                                                                DEL_COMMAND,
                                                                fvVector);
             m_warmStartHelper.insertRefreshMap(kfv);
+            SWSS_LOG_NOTICE("afeigin3");
             return;
         }
     }
@@ -669,6 +671,7 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
         if (!warmRestartInProgress)
         {
             m_routeTable.del(destipprefix);
+            SWSS_LOG_NOTICE("afeigin5");
             return;
         }
         else
@@ -681,6 +684,7 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
                                                                DEL_COMMAND,
                                                                fvVector);
             m_warmStartHelper.insertRefreshMap(kfv);
+            SWSS_LOG_NOTICE("afeigin6, destipprefix: %s", destipprefix);
             return;
         }
     }
@@ -747,6 +751,7 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
             {
                 if (!warmRestartInProgress)
                 {
+                    SWSS_LOG_NOTICE("afeigin0");
                     SWSS_LOG_NOTICE("RouteTable del msg for route with only one nh on eth0/docker0: %s %s %s %s",
                             destipprefix, gw_list.c_str(), intf_list.c_str(), mpls_list.c_str());
 
@@ -754,6 +759,7 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
                 }
                 else
                 {
+                    SWSS_LOG_NOTICE("afeigin1, : %s %s %s %s", destipprefix, gw_list.c_str(), intf_list.c_str(), mpls_list.c_str());
                     SWSS_LOG_NOTICE("Warm-Restart mode: Receiving delete msg for route with only nh on eth0/docker0: %s %s %s %s",
                             destipprefix, gw_list.c_str(), intf_list.c_str(), mpls_list.c_str());
 
@@ -787,6 +793,12 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
 
     if (!warmRestartInProgress  || (fastRestartInProgress && isConnectedRoute(gw_list.c_str())))
     {
+        if (fastRestartInProgress && isConnectedRoute(gw_list.c_str()))
+        {
+            SWSS_LOG_NOTICE("aryehf");
+            SWSS_LOG_NOTICE("-----RouteTable set msg: %s %s %s %s", destipprefix,
+                       gw_list.c_str(), intf_list.c_str(), mpls_list.c_str());
+        }
         m_routeTable.set(destipprefix, fvVector);
         SWSS_LOG_DEBUG("RouteTable set msg: %s %s %s %s", destipprefix,
                        gw_list.c_str(), intf_list.c_str(), mpls_list.c_str());

--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -21,6 +21,9 @@ using namespace swss;
 #define VRF_PREFIX              "Vrf"
 #define MGMT_VRF_PREFIX         "mgmt"
 
+#define IPV4_DEFAULT_ROUTE      "0.0.0.0/0"
+#define IPV6_DEFAULT_ROUTE      "::/0"
+
 #define NHG_DELIMITER ','
 
 #ifndef ETH_ALEN
@@ -659,6 +662,7 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
      * or we could opt to defer it if we are going through a warm-reboot cycle.
      */
     bool warmRestartInProgress = m_warmStartHelper.inProgress();
+    bool fastRestartInProgress = m_warmStartHelper.fastRestartInProgress();
 
     if (nlmsg_type == RTM_DELROUTE)
     {
@@ -781,7 +785,7 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
         fvVector.push_back(wt);
     }
 
-    if (!warmRestartInProgress)
+    if (!warmRestartInProgress  || (fastRestartInProgress && isDefaultRoute(destipprefix)))
     {
         m_routeTable.set(destipprefix, fvVector);
         SWSS_LOG_DEBUG("RouteTable set msg: %s %s %s %s", destipprefix,
@@ -802,6 +806,15 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
                                                            fvVector);
         m_warmStartHelper.insertRefreshMap(kfv);
     }
+}
+
+/* 
+ * Check if given string route is IPV4/IPV6 default route
+ * @arg route      route
+ */
+bool RouteSync::isDefaultRoute(char *route)
+{
+    return (!strcmp (route, IPV4_DEFAULT_ROUTE)) || (!strcmp (route, IPV6_DEFAULT_ROUTE));
 }
 
 /* 

--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -812,9 +812,9 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
  * Check if given nexthop is default gateway.
  * @arg nexthop      nexthop address
  */
-bool RouteSync::isConnectedRoute(char *nexthop)
+bool RouteSync::isConnectedRoute(const char *nexthop)
 {
-    return (!strcmp (route, IPV4_DEFAULT_GATEWAY)) || (!strcmp (route, IPV6_DEFAULT_GATEWAY));
+    return (!strcmp (nexthop, IPV4_DEFAULT_GATEWAY)) || (!strcmp (nexthop, IPV6_DEFAULT_GATEWAY));
 }
 
 /* 

--- a/fpmsyncd/routesync.h
+++ b/fpmsyncd/routesync.h
@@ -87,6 +87,8 @@ private:
 
     /* Get next hop weights*/
     string getNextHopWt(struct rtnl_route *route_obj);
+
+    bool isDefaultRoute(char *route);
 };
 
 }

--- a/fpmsyncd/routesync.h
+++ b/fpmsyncd/routesync.h
@@ -88,7 +88,7 @@ private:
     /* Get next hop weights*/
     string getNextHopWt(struct rtnl_route *route_obj);
 
-    bool isConnectedRoute(char *nexthop);
+    bool isConnectedRoute(const char *nexthop);
 };
 
 }

--- a/fpmsyncd/routesync.h
+++ b/fpmsyncd/routesync.h
@@ -88,7 +88,7 @@ private:
     /* Get next hop weights*/
     string getNextHopWt(struct rtnl_route *route_obj);
 
-    bool isDefaultRoute(char *route);
+    bool isConnectedRoute(char *nexthop);
 };
 
 }

--- a/warmrestart/warmRestartHelper.cpp
+++ b/warmrestart/warmRestartHelper.cpp
@@ -86,6 +86,11 @@ bool WarmStartHelper::inProgress(void) const
     return (m_enabled && m_state != WarmStart::RECONCILED);
 }
 
+bool fastRestartInProgress(void) const
+{
+    return WarmStart::checkFastReboot();
+}
+
 
 uint32_t WarmStartHelper::getRestartTimer(void) const
 {

--- a/warmrestart/warmRestartHelper.cpp
+++ b/warmrestart/warmRestartHelper.cpp
@@ -86,7 +86,7 @@ bool WarmStartHelper::inProgress(void) const
     return (m_enabled && m_state != WarmStart::RECONCILED);
 }
 
-bool fastRestartInProgress(void) const
+bool WarmStartHelper::fastRestartInProgress(void) const
 {
     return WarmStart::checkFastReboot();
 }

--- a/warmrestart/warmRestartHelper.h
+++ b/warmrestart/warmRestartHelper.h
@@ -48,6 +48,8 @@ class WarmStartHelper {
 
     bool inProgress(void) const;
 
+    bool fastRestartInProgress(void) const;
+
     uint32_t getRestartTimer(void) const;
 
     bool runRestoration(void);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Faster setting of default routes for fast-reboot - skipping warm-reboot reconciliation timers. Skip is only for default routes and only in the case fast-reboot is in progress and not warm-reboot.

**Why I did it**
To shorten dataplane downtime as default routes will be set much faster.

**How I verified it**
Manual and automated tests.

**Details if related**
