### PR TITLE
Skip reconcilation waiting for default routes in fast-reboot

### DIFF
--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -22,6 +22,9 @@ using namespace swss;
 #define VRF_PREFIX              "Vrf"
 #define MGMT_VRF_PREFIX         "mgmt"
 
+#define IPV4_DEFAULT_ROUTE      "0.0.0.0/0"
+#define IPV6_DEFAULT_ROUTE      "::/0"
+
 #define NHG_DELIMITER ','
 
 #ifndef ETH_ALEN
@@ -697,6 +700,7 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
      * or we could opt to defer it if we are going through a warm-reboot cycle.
      */
     bool warmRestartInProgress = m_warmStartHelper.inProgress();
+    bool fastRestartInProgress = m_warmStartHelper.fastRestartInProgress();
 
     if (nlmsg_type == RTM_DELROUTE)
     {
@@ -829,7 +833,7 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
         fvVector.push_back(wt);
     }
 
-    if (!warmRestartInProgress)
+    if (!warmRestartInProgress  || (fastRestartInProgress && isDefaultRoute(destipprefix)))
     {
         m_routeTable.set(destipprefix, fvVector);
         SWSS_LOG_DEBUG("RouteTable set msg: %s %s %s %s", destipprefix,
@@ -850,6 +854,15 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
                                                            fvVector);
         m_warmStartHelper.insertRefreshMap(kfv);
     }
+}
+
+/* 
+ * Check if given string route is IPV4/IPV6 default route
+ * @arg route      route
+ */
+bool RouteSync::isDefaultRoute(char *route)
+{
+    return (!strcmp (route, IPV4_DEFAULT_ROUTE)) || (!strcmp (route, IPV6_DEFAULT_ROUTE));
 }
 
 /* 

--- a/fpmsyncd/routesync.h
+++ b/fpmsyncd/routesync.h
@@ -84,6 +84,8 @@ private:
     /* Handle regular route (include VRF route) */
     void onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf);
 
+    bool isDefaultRoute(char *route);
+
     /* Handle label route */
     void onLabelRouteMsg(int nlmsg_type, struct nl_object *obj);
 

--- a/warmrestart/warmRestartHelper.cpp
+++ b/warmrestart/warmRestartHelper.cpp
@@ -86,6 +86,10 @@ bool WarmStartHelper::inProgress(void) const
     return (m_enabled && m_state != WarmStart::RECONCILED);
 }
 
+bool WarmStartHelper::fastRestartInProgress(void) const
+{
+    return WarmStart::checkFastReboot();
+}
 
 uint32_t WarmStartHelper::getRestartTimer(void) const
 {

--- a/warmrestart/warmRestartHelper.h
+++ b/warmrestart/warmRestartHelper.h
@@ -48,6 +48,8 @@ class WarmStartHelper {
 
     bool inProgress(void) const;
 
+    bool fastRestartInProgress(void) const;
+
     uint32_t getRestartTimer(void) const;
 
     bool runRestoration(void);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Faster setting of default routes for fast-reboot - skipping warm-reboot reconciliation timers. Skip is only for default routes and only in the case fast-reboot is in progress and not warm-reboot.

**Why I did it**
To shorten dataplane downtime as default routes will be set much faster.

**How I verified it**
Community advanced-reboot test for fast-reboot and warm-reboot.

**Details if related**
